### PR TITLE
Desktop restyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# adapt-narrative
+# adapt-contrib-narrative  
+
+**Narrative** is a *presentation component* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).  
+
+<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/narrative01.gif" alt="narrative in action">
+
+**Narrative** displays items (or slides) that present an image and text side-by-side. Left and right navigation controls allow the learner to progress horizontally through the items. Optional text may precede it. Useful for detailing a sequential process. On mobile devices, the narrative text is collapsed above the image.
+
+[Visit the **Narrative** wiki](https://github.com/adaptlearning/adapt-contrib-narrative/wiki) for more information about its functionality and for explanations of key properties.
+
+## Installation
+
+As one of Adapt's *[core components](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#components),* **Narrative** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
+
+* If **Narrative** has been uninstalled from the Adapt framework, it may be reinstalled.
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:  
+`adapt install adapt-contrib-narrative`
+
+    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:  
+    `"adapt-contrib-narrative": "*"`  
+    Then running the command:  
+    `adapt install`  
+    (This second method will reinstall all plug-ins listed in *adapt.json*.)  
+
+* If **Narrative** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).  
+<div float align=right><a href="#top">Back to Top</a></div>
+
+## Settings Overview
+
+The attributes listed below are used in *components.json* to configure **Narrative**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/example.json). Visit the [**Narrative** wiki](https://github.com/adaptlearning/adapt-contrib-narrative/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).
+
+### Attributes
+
+[**core model attributes**](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes): These are inherited by every Adapt component. [Read more](https://github.com/adaptlearning/adapt_framework/wiki/Core-model-attributes).
+
+**_component** (string): This value must be: `narrative`.
+
+**_classes** (string): CSS class name to be applied to **Narrative**’s containing div. The class must be predefined in one of the Less files. Separate multiple classes with a space.
+
+**_layout** (string): This defines the horizontal position of the component in the block. Acceptable values are `full`, `left` or `right`; however, `full` is typically the only option used as `left` or `right` do not allow much room for the component to display.
+
+**instruction** (string): This optional text appears above the component. It is frequently used to guide the learner’s interaction with the component.   
+
+**_hasNavigationInTextArea** (boolean): Determines the location of the arrows (icons) used to navigate from slide to slide. Navigation can overlay the image or the text. Set to `true` to have the navigation controls appear in the text region.
+
+**_setCompletionOn** (string): This value determines when the component registers as complete. Acceptable values are `"allItems"` and `"inview"`. `"allItems"` requires the learner to navigate to each slide. `"inview"` requires the **Narrative** component to enter the view port completely, top and bottom.
+
+**_items** (array): Multiple items may be created. Each item represents one slide and contains values for the narrative (**title**, **subTitle**, **body**), the image (**_graphic**).
+
+>**title** (string): This value is the title for this stage of the narrative element.
+
+>**subTitle** (string): This value is the subTitle for this stage of the narrative element.
+
+>**body** (string): This is the main text for this stage of the narrative element.
+
+>**_graphic** (object): The image that appears next to the narrative text. It contains values for **src**, **alt**, and **attribution**.
+
+>>**src** (string): File name (including path) of the image. Path should be relative to the *src* folder (e.g.,*course/en/images/origami-menu-two.jpg*).
+
+>>**alt** (string): This text becomes the image’s `alt` attribute.
+
+>>**attribution** (string): Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
+
+### Accessibility  
+**Narrative** has been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **ariaRegion**. This label is not a visible element. It is utilized by assistive technology such as screen readers. Should the region's text need to be customised, it can be found within the **globals** object in [*properties.schema*](https://github.com/adaptlearning/adapt-contrib-narrative/blob/master/properties.schema).   
+<div float align=right><a href="#top">Back to Top</a></div>
+
+## Limitations
+ 
+On mobile devices, the narrative text is collapsed above the image. It is accessed by clicking an icon (+) next the to strapline.
+
+----------------------------
+**Version number:**  2.1.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Framework versions:** 2+  
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-narrative/graphs/contributors)    
+**Accessibility support:** WAI AA   
+**RTL support:** yes  
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge 12, IE 11, IE10, IE9, IE8, IE Mobile 11, Safari iOS 9+10, Safari OS X 9+10, Opera

--- a/example.json
+++ b/example.json
@@ -5,33 +5,41 @@
     "_component":"narrative",
     "_classes":"",
     "_layout":"left",
-    "title":"Our first look at a component",
-    "displayTitle":"Our first look at a component",
-    "body":"This component you're reading is a narrative component.",
-    "instruction":"",
+    "title":"Narrative Component",
+    "displayTitle":"Narrative Component",
+    "body":"The Narrative component lets you scroll through a series of images each with some accompanying text.<br><br>This component may be used in both single- and full-width layouts.",
+    "instruction":"Select the arrows to find out more.",
     "_currentIndex": 0,
     "counterText": " {{{inc _currentIndex}}} / {{{_items.length}}} ",
     "backText": "",
-    "_backIconClass": "",
+    "_backIconClass": "icon-controls-small-left",
     "nextText": "",
-    "_nextIconClass": "",
+    "_nextIconClass": "icon-controls-small-right",
     "_loop": true,
     "_items": [
         {
             "_graphic": {
                 "_src": "course/en/images/single_width.jpg"
             },
-            "title": "Title",
+            "title": "Item 1 Title",
             "subtitle": "SubTitle",
-            "body": "This is some display text"
+            "body": "Narratives are particularly good for showing dialogue between two or more characters, with each step of the conversation being accompanied by an image. This photo story approach can be used to provide context for the learning to follow, to illustrate real-world application of the learning or to show the impact on people when the learning hasn’t been applied correctly."
         },
         {
             "_graphic": {
                 "_src": "course/en/images/single_width.jpg"
             },
-            "title": "Title",
+            "title": "Item 2 Title",
             "subtitle": "SubTitle",
-            "body": "This is some display text"
+            "body": "Narratives can also be used to present case studies, where the different displays are used to set the scene, show the key events and then the outcome."
+        },
+        {
+            "_graphic": {
+                "_src": "course/en/images/single_width.jpg"
+            },
+            "title": "Item 3 Title",
+            "subtitle": "SubTitle",
+            "body": "The narrative can also be used when you want to illustrate the constituent steps that make up a larger process."
         }
     ]
 }

--- a/js/view.js
+++ b/js/view.js
@@ -15,6 +15,9 @@ define([
 
         postRender: function() {
             this.setReadyStatus();
+            if (this.model.get('_hasEqualHtTextBoxes')) {
+                this.setBodyHeight();
+            }
 
             _.bindAll(this, "onSwipe");
             this.$(".items-container").on({
@@ -101,6 +104,16 @@ define([
             this.reRender();
         },
 
+        setBodyHeight: function() {
+            var elementHeights = this.$('.narrative-text-inner').map(function() {
+                return $(this).outerHeight(true);
+            }).get();
+            
+            var maxHeight = Math.max.apply(null, elementHeights);
+
+            this.$('.narrative-text-inner').css({minHeight: maxHeight});
+        },
+
         remove: function() {
             this.$(".items-container").off({
                 "swipeleft": this.onSwipe,
@@ -115,3 +128,4 @@ define([
 
     return Narrative;
 });
+

--- a/less/narrative.less
+++ b/less/narrative.less
@@ -37,18 +37,71 @@
         display: inline-block;
         font-size: @body-text-font-size;
         line-height: @body-line-height;
+        vertical-align: top;
+    }
+
+    .narrative-text-inner {
+        padding-top: @item-padding-top;
+        //uncomment the following when using a transparent component background
+        //padding: @item-padding;
+        //background-color: @component-background-color;
+    }
+
+    .narrative-text-title { //to be moved to adapt-contrib-vanilla/less/src/narrative.less
+        .item-title;
+        margin-bottom: @title-text-margin;
+    }
+
+    button .icon {
+        color: @item-text-color;
     }
 
     .controls {
         position: absolute;
         right: 0;
         bottom: 0;
-        background-color: black;
+        background-color: @item-color;
+    }
+
+    .back, .next {
+        padding: @item-padding;
     }
 
     .counter {
         display: inline-block;
-        color: white;
+        padding: @item-padding;
+        color: @item-text-color;
+        vertical-align: baseline;
     }
 
+    // Styles for desktop, layout: full
+    @media all and (min-width: (@device-width-small + 1)) {
+
+        &.component-full {
+
+            .component-widget {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-between;
+                align-items: flex-start;
+            }
+
+            .items-container {
+                flex-basis: auto;
+                width: 60%;
+                .dir-rtl & {
+                    margin-right: inherit;
+                }
+            }
+
+            .texts {
+                flex-basis: auto;
+                width: 36%;
+            }
+
+            .narrative-text-inner {
+                padding-top: 0;
+            }
+        }
+    }
 }

--- a/templates/narrative.hbs
+++ b/templates/narrative.hbs
@@ -10,9 +10,9 @@
                 </div>
             </div>
             <div class="controls">
-                <div class="counter">{{{compile counterText this}}}</div>
-                <button class="back">{{#if _backIconClass}}<div class="icon {{_backIconClass}}"></div>{{/if}}{{{compile backText this}}}</button>
-                <button class="next">{{#if _nextIconClass}}<div class="icon {{_nextIconClass}}"></div>{{/if}}{{{compile nextText this}}}</button>
+                <div class="counter">{{{compile counterText}}}</div>
+                <button class="base back">{{#if _backIconClass}}<div class="icon {{_backIconClass}}"></div>{{/if}}{{{compile backText}}}</button>
+                <button class="base next">{{#if _nextIconClass}}<div class="icon {{_nextIconClass}}"></div>{{/if}}{{{compile nextText}}}</button>
             </div>
         </div>
         <div class="texts">

--- a/templates/partials/narrativeText.hbs
+++ b/templates/partials/narrativeText.hbs
@@ -1,5 +1,7 @@
 <div class="narrative-text" style="width: calc(100% / {{@root/_items.length}});">
-    {{#if title}}<div class="narrative-title">{{{title}}}</div>{{/if}}
-    {{#if subtitle}}<div class="narrative-subtitle">{{{subtitle}}}</div>{{/if}}
-    {{#if body}}<div class="narrative-body">{{{body}}}</div>{{/if}}
+    <div class="narrative-text-inner">
+        {{#if title}}<div class="narrative-text-title">{{{title}}}</div>{{/if}}
+        {{#if subtitle}}<div class="narrative-text-subtitle">{{{subtitle}}}</div>{{/if}}
+        {{#if body}}<div class="narrative-text-body">{{{body}}}</div>{{/if}}
+    </div>
 </div>


### PR DESCRIPTION
Goal was to modify full-width desktop presentation so that graphic and text are side-by-side.
Also:
- Added `texts-inner` to make it easier to style the stage texts when the component `background-color` is transparent.
- Added `setBodyHeight()` due to frequent client requests.
- Buttons styling was modeled on Hot Graphic's popup toolbar.
- Added class `base` to `button` to match Hot Graphic.
- Removed `this` from `compile` where it appears in the subelements of the `controls` div; was uncertain of its necessity, however, everything appears to work anyway. 
- `component-widget` is styled using flexbox.
- Added content to README, but maybe that was jumping the gun since some properties present in the original README are not present in this version.